### PR TITLE
Update to latest version ffi 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "debug": "*",
-    "ffi": "https://github.com/icenium/node-ffi/tarball/master",
+    "ffi": "https://github.com/node-ffi/node-ffi/tarball/master",
     "ref": "https://github.com/icenium/ref/tarball/master",
     "ref-struct": "https://github.com/telerik/ref-struct/tarball/master"
   },


### PR DESCRIPTION
ffi@1.2.7 give me an error and ffi@1.3.2 works

	➜  ~  node -v
	v0.12.7

	➜  ~  npm -v
	2.12.1


	➜  ~  make --version
	GNU Make 3.81
	Copyright (C) 2006  Free Software Foundation, Inc.
	This is free software; see the source for copying conditions.
	There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
	PARTICULAR PURPOSE.
	This program built for i386-apple-darwin11.3.0


	➜  ~  gcc --version
	Configured with: --prefix=/Applications/Xcode-beta.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
	Apple LLVM version 7.0.0 (clang-700.0.57.2)
	Target: x86_64-apple-darwin15.0.0
	Thread model: posix


    > ffi@1.2.7 install /usr/local/lib/node_modules/nativescript/node_modules/ios-sim-portable/node_modules/NodObjC/node_modules/ffi
    > node ./build.js

    child_process: customFds option is deprecated, use stdio instead.
      CC(target) Release/obj.target/ffi/deps/libffi/src/prep_cif.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/types.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/raw_api.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/java_raw_api.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/closures.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/x86/ffi.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/x86/ffi64.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/x86/darwin.o
      CC(target) Release/obj.target/ffi/deps/libffi/src/x86/darwin64.o
      LIBTOOL-STATIC Release/libffi.a
      CXX(target) Release/obj.target/ffi_bindings/src/ffi.o
    In file included from ../src/ffi.cc:3:
    ../src/ffi.h:51:5: error: unknown type name 'NanCallback'
        NanCallback *callback;
        ^
    ../src/ffi.h:81:3: error: unknown type name 'NanCallback'
      NanCallback* function;         // JS callback function the closure represents
      ^
    ../src/ffi.cc:20:3: error: use of undeclared identifier 'NanEscapableScope'
      NanEscapableScope();
      ^
    ../src/ffi.cc:25:5: error: use of undeclared identifier 'NanNewBufferHandle'
        NanNewBufferHandle(ptr, length, wrap_pointer_cb, user_data)
        ^
    ../src/ffi.cc:32:21: error: use of undeclared identifier 'NanNew'
      Local<Object> o = NanNew<Object>();
                        ^
    ../src/ffi.cc:32:28: error: 'Object' does not refer to a value
      Local<Object> o = NanNew<Object>();
                               ^
    /Users/gerson/.node-gyp/0.12.7/deps/v8/include/v8.h:2110:17: note: declared here
    class V8_EXPORT Object : public Value {
                    ^
    ../src/ffi.cc:32:36: error: expected expression
      Local<Object> o = NanNew<Object>();
                                       ^
    ../src/ffi.cc:35:10: error: use of undeclared identifier 'NanNew'
      o->Set(NanNew<String>("dlopen"),  WrapPointer((char *)dlopen));
             ^
    ../src/ffi.cc:35:17: error: 'String' does not refer to a value
      o->Set(NanNew<String>("dlopen"),  WrapPointer((char *)dlopen));
                    ^
    /Users/gerson/.node-gyp/0.12.7/deps/v8/include/v8.h:1599:17: note: declared here
    class V8_EXPORT String : public Primitive {
                    ^
    ../src/ffi.cc:36:10: error: use of undeclared identifier 'NanNew'
      o->Set(NanNew<String>("dlclose"), WrapPointer((char *)dlclose));
             ^
    ../src/ffi.cc:36:17: error: 'String' does not refer to a value
      o->Set(NanNew<String>("dlclose"), WrapPointer((char *)dlclose));
                    ^
    /Users/gerson/.node-gyp/0.12.7/deps/v8/include/v8.h:1599:17: note: declared here
    class V8_EXPORT String : public Primitive {
                    ^
    ../src/ffi.cc:37:10: error: use of undeclared identifier 'NanNew'
      o->Set(NanNew<String>("dlsym"),   WrapPointer((char *)dlsym));
             ^
    ../src/ffi.cc:37:17: error: 'String' does not refer to a value
      o->Set(NanNew<String>("dlsym"),   WrapPointer((char *)dlsym));
                    ^
    /Users/gerson/.node-gyp/0.12.7/deps/v8/include/v8.h:1599:17: note: declared here
    class V8_EXPORT String : public Primitive {
                    ^
    ../src/ffi.cc:38:10: error: use of undeclared identifier 'NanNew'
      o->Set(NanNew<String>("dlerror"), WrapPointer((char *)dlerror));
             ^
    ../src/ffi.cc:38:17: error: 'String' does not refer to a value
      o->Set(NanNew<String>("dlerror"), WrapPointer((char *)dlerror));
                    ^
    /Users/gerson/.node-gyp/0.12.7/deps/v8/include/v8.h:1599:17: note: declared here
    class V8_EXPORT String : public Primitive {
                    ^
    ../src/ffi.cc:40:15: error: use of undeclared identifier 'NanNew'
      target->Set(NanNew<String>("StaticFunctions"), o);
                  ^
    ../src/ffi.cc:40:22: error: 'String' does not refer to a value
      target->Set(NanNew<String>("StaticFunctions"), o);
                         ^
    /Users/gerson/.node-gyp/0.12.7/deps/v8/include/v8.h:1599:17: note: declared here
    class V8_EXPORT String : public Primitive {
                    ^
    ../src/ffi.cc:53:3: error: no matching function for call to 'NODE_SET_METHOD'
      NODE_SET_METHOD(target, "ffi_prep_cif", FFIPrepCif);
      ^~~~~~~~~~~~~~~
    /Users/gerson/.node-gyp/0.12.7/src/node.h:240:25: note: expanded from macro 'NODE_SET_METHOD'
    #define NODE_SET_METHOD node::NODE_SET_METHOD
                            ^~~~~~~~~~~~~~~~~~~~~
    /Users/gerson/.node-gyp/0.12.7/src/node.h:228:13: note: candidate function [with TypeName = v8::Handle<v8::Object>] not viable: no known conversion from
          'Nan::NAN_METHOD_RETURN_TYPE (Nan::NAN_METHOD_ARGS_TYPE)' to 'v8::FunctionCallback' (aka 'void (*)(const FunctionCallbackInfo<v8::Value> &)') for
          3rd argument
    inline void NODE_SET_METHOD(const TypeName& recv,
                ^
    ../src/ffi.cc:54:3: error: no matching function for call to 'NODE_SET_METHOD'
      NODE_SET_METHOD(target, "ffi_prep_cif_var", FFIPrepCifVar);
      ^~~~~~~~~~~~~~~
    /Users/gerson/.node-gyp/0.12.7/src/node.h:240:25: note: expanded from macro 'NODE_SET_METHOD'
    #define NODE_SET_METHOD node::NODE_SET_METHOD
                            ^~~~~~~~~~~~~~~~~~~~~
    /Users/gerson/.node-gyp/0.12.7/src/node.h:228:13: note: candidate function [with TypeName = v8::Handle<v8::Object>] not viable: no known conversion from
          'Nan::NAN_METHOD_RETURN_TYPE (Nan::NAN_METHOD_ARGS_TYPE)' to 'v8::FunctionCallback' (aka 'void (*)(const FunctionCallbackInfo<v8::Value> &)') for
          3rd argument
    inline void NODE_SET_METHOD(const TypeName& recv,
                ^
    fatal error: too many errors emitted, stopping now [-ferror-limit=]
    20 errors generated.
    make: *** [Release/obj.target/ffi_bindings/src/ffi.o] Error 1
    gyp ERR! build error 
    gyp ERR! stack Error: `make` failed with exit code: 2
    gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:269:23)
    gyp ERR! stack     at ChildProcess.emit (events.js:110:17)
    gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:1074:12)
    gyp ERR! System Darwin 15.0.0
    gyp ERR! command "node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
    gyp ERR! cwd /usr/local/lib/node_modules/nativescript/node_modules/ios-sim-portable/node_modules/NodObjC/node_modules/ffi
    gyp ERR! node -v v0.12.7
    gyp ERR! node-gyp -v v2.0.1
    gyp ERR! not ok 
    Build failed
    npm ERR! Darwin 15.0.0
    npm ERR! argv "node" "/usr/local/bin/npm" "install" "nativescript" "-g"
    npm ERR! node v0.12.7
    npm ERR! npm  v2.12.1
    npm ERR! code ELIFECYCLE

    npm ERR! ffi@1.2.7 install: `node ./build.js`
    npm ERR! Exit status 1
    npm ERR! 
    npm ERR! Failed at the ffi@1.2.7 install script 'node ./build.js'.
    npm ERR! This is most likely a problem with the ffi package,
    npm ERR! not with npm itself.
    npm ERR! Tell the author that this fails on your system:
    npm ERR!     node ./build.js
    npm ERR! You can get their info via:
    npm ERR!     npm owner ls ffi
    npm ERR! There is likely additional logging output above.

