### PR TITLE
Add support for node 5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "debug": "*",
-    "ffi": "https://github.com/icenium/node-ffi/tarball/v2.0.0.0",
-    "ref": "https://github.com/icenium/ref/tarball/v1.1.3.0",
-    "ref-struct": "https://github.com/telerik/ref-struct/tarball/v1.0.2.0"
+    "ffi": "https://github.com/icenium/node-ffi/tarball/v2.0.0.1",
+    "ref": "https://github.com/icenium/ref/tarball/v1.1.3.1",
+    "ref-struct": "https://github.com/telerik/ref-struct/tarball/v1.0.2.1"
   },
   "devDependencies": {
     "libxmljs": "~0.14.3",


### PR DESCRIPTION
Add support for node 5.1 by updating ref, ref-struct and ffi dependencies.